### PR TITLE
Set minimum required {n2khab} version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     curl,
     dplyr,
     git2rdata,
-    n2khab,
+    n2khab (>= 0.10.0),
     remotes,
     rlang,
     stringr,


### PR DESCRIPTION
`read_schemes()` and `read_scheme_types()` require the updated `namelist` from {n2khab} >= 0.10.0 to work correctly.

This requirement could only be set after releasing {n2khab} 0.10.0, which in itself required a release of {n2khabmon} 0.1.0 as it refers these functions already. So {n2khabmon} had to be released in two steps; this prepares the second step.